### PR TITLE
feat: add transition mixin

### DIFF
--- a/scss/02-tools/_mixins.scss
+++ b/scss/02-tools/_mixins.scss
@@ -66,6 +66,10 @@
   animation: #{$str};
 }
 
+@mixin transition($str) {
+  transition: #{$str};
+}
+
 ///  MEDIA QUERIES
 
 ///  pre tab


### PR DESCRIPTION
Bug in previous PR: generated css had the transition string in quotes instead of just the string due to a missing mixin